### PR TITLE
Adaptable testlogger

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,7 @@
 
 	<testsuites>
 		<testsuite name="Tests">
-			<directory suffix=".php">./tests</directory>
+			<directory suffix="Test.php">./tests</directory>
 		</testsuite>
 	</testsuites>
 

--- a/tests/Mpdf/TestLogger.php
+++ b/tests/Mpdf/TestLogger.php
@@ -1,100 +1,13 @@
 <?php
-
-namespace Mpdf;
-
-/**
- * Copied from PSR repository where not available since 2.x
- */
-class TestLogger extends \Psr\Log\AbstractLogger
-{
-
-	/**
-	 * @var mixed[]
-	 */
-	public $records = [];
-
-	public $recordsByLevel = [];
-
-	/**
-	 * @inheritdoc
-	 */
-	public function log($level, $message, array $context = [])
-	{
-		$record = [
-			'level' => $level,
-			'message' => $message,
-			'context' => $context,
-		];
-
-		$this->recordsByLevel[$record['level']][] = $record;
-		$this->records[] = $record;
-	}
-
-	public function hasRecords($level)
-	{
-		return isset($this->recordsByLevel[$level]);
-	}
-
-	public function hasRecord($record, $level)
-	{
-		if (is_string($record)) {
-			$record = ['message' => $record];
-		}
-		return $this->hasRecordThatPasses(function ($rec) use ($record) {
-			if ($rec['message'] !== $record['message']) {
-				return false;
-			}
-			if (isset($record['context']) && $rec['context'] !== $record['context']) {
-				return false;
-			}
-			return true;
-		}, $level);
-	}
-
-	public function hasRecordThatContains($message, $level)
-	{
-		return $this->hasRecordThatPasses(function ($rec) use ($message) {
-			return strpos($rec['message'], $message) !== false;
-		}, $level);
-	}
-
-	public function hasRecordThatMatches($regex, $level)
-	{
-		return $this->hasRecordThatPasses(function ($rec) use ($regex) {
-			return preg_match($regex, $rec['message']) > 0;
-		}, $level);
-	}
-
-	public function hasRecordThatPasses(callable $predicate, $level)
-	{
-		if (!isset($this->recordsByLevel[$level])) {
-			return false;
-		}
-		foreach ($this->recordsByLevel[$level] as $i => $rec) {
-			if (call_user_func($predicate, $rec, $i)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	public function __call($method, $args)
-	{
-		if (preg_match('/(.*)(Debug|Info|Notice|Warning|Error|Critical|Alert|Emergency)(.*)/', $method, $matches) > 0) {
-			$genericMethod = $matches[1] . ('Records' !== $matches[3] ? 'Record' : '') . $matches[3];
-			$level = strtolower($matches[2]);
-			if (method_exists($this, $genericMethod)) {
-				$args[] = $level;
-				return call_user_func_array([$this, $genericMethod], $args);
-			}
-		}
-		throw new \BadMethodCallException('Call to undefined method ' . get_class($this) . '::' . $method . '()');
-	}
-
-	public function reset()
-	{
-		$this->records = [];
-		$this->recordsByLevel = [];
-	}
-
+// Due to changes in signature of log() method (one with return type declared,
+// the other with no return type declared) we adapt which class is actually
+// included based on the signature of \Psr\Log\AbstractLogger included by
+// Composer.
+$reflection = new \ReflectionClass('\Psr\Log\AbstractLogger');
+$return_type = $reflection->getMethod('log')->getReturnType();
+if (empty($return_type)) {
+  include __DIR__ . "/psr-log-2/TestLogger.php";
+}
+else {
+  include __DIR__ . "/psr-log-3/TestLogger.php";
 }

--- a/tests/Mpdf/psr-log-2/TestLogger.php
+++ b/tests/Mpdf/psr-log-2/TestLogger.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Mpdf;
+
+/**
+ * Copied from PSR repository where not available since 2.x
+ */
+class TestLogger extends \Psr\Log\AbstractLogger
+{
+
+	/**
+	 * @var mixed[]
+	 */
+	public $records = [];
+
+	public $recordsByLevel = [];
+
+	/**
+	 * @inheritdoc
+	 */
+	public function log($level, $message, array $context = [])
+	{
+		$record = [
+			'level' => $level,
+			'message' => $message,
+			'context' => $context,
+		];
+
+		$this->recordsByLevel[$record['level']][] = $record;
+		$this->records[] = $record;
+	}
+
+	public function hasRecords($level)
+	{
+		return isset($this->recordsByLevel[$level]);
+	}
+
+	public function hasRecord($record, $level)
+	{
+		if (is_string($record)) {
+			$record = ['message' => $record];
+		}
+		return $this->hasRecordThatPasses(function ($rec) use ($record) {
+			if ($rec['message'] !== $record['message']) {
+				return false;
+			}
+			if (isset($record['context']) && $rec['context'] !== $record['context']) {
+				return false;
+			}
+			return true;
+		}, $level);
+	}
+
+	public function hasRecordThatContains($message, $level)
+	{
+		return $this->hasRecordThatPasses(function ($rec) use ($message) {
+			return strpos($rec['message'], $message) !== false;
+		}, $level);
+	}
+
+	public function hasRecordThatMatches($regex, $level)
+	{
+		return $this->hasRecordThatPasses(function ($rec) use ($regex) {
+			return preg_match($regex, $rec['message']) > 0;
+		}, $level);
+	}
+
+	public function hasRecordThatPasses(callable $predicate, $level)
+	{
+		if (!isset($this->recordsByLevel[$level])) {
+			return false;
+		}
+		foreach ($this->recordsByLevel[$level] as $i => $rec) {
+			if (call_user_func($predicate, $rec, $i)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public function __call($method, $args)
+	{
+		if (preg_match('/(.*)(Debug|Info|Notice|Warning|Error|Critical|Alert|Emergency)(.*)/', $method, $matches) > 0) {
+			$genericMethod = $matches[1] . ('Records' !== $matches[3] ? 'Record' : '') . $matches[3];
+			$level = strtolower($matches[2]);
+			if (method_exists($this, $genericMethod)) {
+				$args[] = $level;
+				return call_user_func_array([$this, $genericMethod], $args);
+			}
+		}
+		throw new \BadMethodCallException('Call to undefined method ' . get_class($this) . '::' . $method . '()');
+	}
+
+	public function reset()
+	{
+		$this->records = [];
+		$this->recordsByLevel = [];
+	}
+
+}

--- a/tests/Mpdf/psr-log-3/TestLogger.php
+++ b/tests/Mpdf/psr-log-3/TestLogger.php
@@ -1,0 +1,99 @@
+<?php
+namespace Mpdf;
+
+/**
+ * Copied from PSR repository where not available since 2.x
+ */
+class TestLogger extends \Psr\Log\AbstractLogger
+{
+
+	/**
+	 * @var mixed[]
+	 */
+	public $records = [];
+
+	public $recordsByLevel = [];
+
+	/**
+	 * @inheritdoc
+	 */
+	public function log($level, $message, array $context = []): void
+	{
+		$record = [
+			'level' => $level,
+			'message' => $message,
+			'context' => $context,
+		];
+
+		$this->recordsByLevel[$record['level']][] = $record;
+		$this->records[] = $record;
+	}
+
+	public function hasRecords($level)
+	{
+		return isset($this->recordsByLevel[$level]);
+	}
+
+	public function hasRecord($record, $level)
+	{
+		if (is_string($record)) {
+			$record = ['message' => $record];
+		}
+		return $this->hasRecordThatPasses(function ($rec) use ($record) {
+			if ($rec['message'] !== $record['message']) {
+				return false;
+			}
+			if (isset($record['context']) && $rec['context'] !== $record['context']) {
+				return false;
+			}
+			return true;
+		}, $level);
+	}
+
+	public function hasRecordThatContains($message, $level)
+	{
+		return $this->hasRecordThatPasses(function ($rec) use ($message) {
+			return strpos($rec['message'], $message) !== false;
+		}, $level);
+	}
+
+	public function hasRecordThatMatches($regex, $level)
+	{
+		return $this->hasRecordThatPasses(function ($rec) use ($regex) {
+			return preg_match($regex, $rec['message']) > 0;
+		}, $level);
+	}
+
+	public function hasRecordThatPasses(callable $predicate, $level)
+	{
+		if (!isset($this->recordsByLevel[$level])) {
+			return false;
+		}
+		foreach ($this->recordsByLevel[$level] as $i => $rec) {
+			if (call_user_func($predicate, $rec, $i)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public function __call($method, $args)
+	{
+		if (preg_match('/(.*)(Debug|Info|Notice|Warning|Error|Critical|Alert|Emergency)(.*)/', $method, $matches) > 0) {
+			$genericMethod = $matches[1] . ('Records' !== $matches[3] ? 'Record' : '') . $matches[3];
+			$level = strtolower($matches[2]);
+			if (method_exists($this, $genericMethod)) {
+				$args[] = $level;
+				return call_user_func_array([$this, $genericMethod], $args);
+			}
+		}
+		throw new \BadMethodCallException('Call to undefined method ' . get_class($this) . '::' . $method . '()');
+	}
+
+	public function reset()
+	{
+		$this->records = [];
+		$this->recordsByLevel = [];
+	}
+
+}


### PR DESCRIPTION
Tests of the psr/log v2 and v3 support fail on the php 7.x tests due to TestLogger.php::log() having a different file signature than the vendor supplied \Psr\Log\AbstractLogger. This PR allows for the TestLogger class to adapt its declaration based on its parent abstract class log() signature.