### PR TITLE
Fix php code sniffer spaces to tabs

### DIFF
--- a/tests/Mpdf/TestLogger.php
+++ b/tests/Mpdf/TestLogger.php
@@ -3,11 +3,13 @@
 // the other with no return type declared) we adapt which class is actually
 // included based on the signature of \Psr\Log\AbstractLogger included by
 // Composer.
-$reflection = new \ReflectionClass('\Psr\Log\AbstractLogger');
-$return_type = $reflection->getMethod('log')->getReturnType();
-if (empty($return_type)) {
-	include __DIR__ . "/psr-log-2/TestLogger.php";
-}
-else {
+$loggerReflect = new \ReflectionClass('\Psr\Log\AbstractLogger');
+// Will throw desirable exception if AbstractLogger does not implement log().
+$loggerLogMethodReflect = $loggerReflect->getMethod('log');
+if (method_exists($loggerLogMethodReflect, 'getReturnType') && $loggerLogMethodReflect->getReturnType()) {
 	include __DIR__ . "/psr-log-3/TestLogger.php";
 }
+else {
+	include __DIR__ . "/psr-log-2/TestLogger.php";
+}
+

--- a/tests/Mpdf/TestLogger.php
+++ b/tests/Mpdf/TestLogger.php
@@ -6,8 +6,8 @@
 $reflection = new \ReflectionClass('\Psr\Log\AbstractLogger');
 $return_type = $reflection->getMethod('log')->getReturnType();
 if (empty($return_type)) {
-  include __DIR__ . "/psr-log-2/TestLogger.php";
+	include __DIR__ . "/psr-log-2/TestLogger.php";
 }
 else {
-  include __DIR__ . "/psr-log-3/TestLogger.php";
+	include __DIR__ . "/psr-log-3/TestLogger.php";
 }


### PR DESCRIPTION
Latest tests show I put in two spaces instead of a tab character in two places. 

This failed the CI linting. *sniff* 😢 

Curious how you get your editor to auto-comply with a project. I notice that none of your changes threw errors, and if your editor had been set to default Drupal standards, errors would have been thrown on code sniffing. So wondering how you manage that as you work across projects. 

In any case, here's a fix for the code sniff failure.